### PR TITLE
Fix tests (close #20)

### DIFF
--- a/spec/integration/bad1_spec.lua
+++ b/spec/integration/bad1_spec.lua
@@ -63,12 +63,9 @@ describe("Integration tests with bad config", function()
   it("should be reusable if the error is caught", function()
     local t1 = snowplow.newTrackerForCf("d3rkrsqld9gmqf")
     t1:encodeBase64(false)
-    status, err = pcall(t1.platform, t1, false)
+    local status, err = pcall(t1.platform, t1, false)
     assert.are.equal(status, false)
-    assert.are.equal(
-      err,
-      "src/snowplow/validate.lua:73: platform must be a string from the set {pc, mob, cnsl, tv, iot}, not [false]"
-    )
+    assert.is_not_nil(err:find("platform must be a string from the set {cnsl, iot, mob, pc, tv}, not %[false%]"))
 
     assert.has_no.errors(function()
       t1:platform("cnsl")

--- a/spec/integration/bad2_spec.lua
+++ b/spec/integration/bad2_spec.lua
@@ -15,9 +15,18 @@
 -- Copyright:   Copyright (c) 2013 Snowplow Analytics Ltd
 -- License:     Apache License Version 2.0
 
-local snowplow = require("snowplow")
+local snowplow
 
 describe("Integration tests with HTTP/collector problems", function()
+  setup(function()
+    _G._TEST = true
+    snowplow = require("snowplow")
+  end)
+
+  teardown(function()
+    _G._TEST = nil
+  end)
+
   it("should return false and an error message if a CloudFront collector cannot be found", function()
     local t = snowplow.newTrackerForCf("fake") -- Doesn't exist
     t:encodeBase64(false)

--- a/spec/unit/tracker_spec.lua
+++ b/spec/unit/tracker_spec.lua
@@ -20,7 +20,18 @@ local tracker = require("tracker")
 local collectorUri = "http://d3rkrsqld9gmqf.cloudfront.net/i"
 
 describe("tracker", function()
-  local t = tracker.newTracker(collectorUri)
+  setup(function()
+    _G._TEST = true
+  end)
+
+  teardown(function()
+    _G._TEST = nil
+  end)
+
+  local t
+  before_each(function()
+    t = tracker.newTracker(collectorUri)
+  end)
 
   -- --------------------------------------------------------------
   -- Constructor tests
@@ -61,7 +72,7 @@ describe("tracker", function()
     local f = function()
       t:platform("fake")
     end
-    assert.has_error(f, "platform must be a string from the set {pc, mob, cnsl, tv, iot}, not [fake]")
+    assert.has_error(f, "platform must be a string from the set {cnsl, iot, mob, pc, tv}, not [fake]")
   end)
 
   it("encodeBase64() should update the Tracker's encodeBase64 configuration setting", function()
@@ -135,8 +146,6 @@ describe("tracker", function()
   -- --------------------------------------------------------------
   -- track...() tests
 
-  spy.on(t, "_httpGet")
-
   it("trackScreenView() should error unless name is a non-empty string", function()
     local f = function()
       t:trackScreenView(-23, "23")
@@ -159,8 +168,16 @@ describe("tracker", function()
   end)
 
   it("trackScreenView() should call httpGet() with the correct payload in the querystring", function()
+    stub(t, "_httpGet")
+    t:setUserId("user123")
+    t:setAppId("wow-ext-1")
+    t:platform("tv")
+    t:setColorDepth(32)
+    t:setScreenResolution(1068, 720)
+    t:setViewport(420, 360)
+
     local s, msg = t:trackScreenView("Game HUD 2", nil, 1369330916)
-    assert.spy(t._httpGet).was_called_with(
+    assert.stub(t._httpGet).was_called_with(
       "http://d3rkrsqld9gmqf.cloudfront.net/i?e=sv&sv_na=Game+HUD+2&dtm=1369330916000&p=tv&tv=lua-0.1.0-1&tid=100000&uid=user123&aid=wow%2Dext%2D1&res=1068x720&vp=420x360&cd=32"
     )
   end)
@@ -208,8 +225,15 @@ describe("tracker", function()
   end)
 
   it("trackStructEvent() should call httpGet() with the correct payload in the querystring", function()
+    stub(t, "_httpGet")
+    t:setUserId("user123")
+    t:setAppId("wow-ext-1")
+    t:platform("tv")
+    t:setColorDepth(32)
+    t:setScreenResolution(1068, 720)
+    t:setViewport(420, 360)
     t:trackStructEvent("shop", "add-to-basket", nil, "units", 2, 1369330909)
-    assert.spy(t._httpGet).was_called_with(
+    assert.stub(t._httpGet).was_called_with(
       "http://d3rkrsqld9gmqf.cloudfront.net/i?e=se&se_ca=shop&se_ac=add%2Dto%2Dbasket&se_pr=units&se_va=2&dtm=1369330909000&p=tv&tv=lua-0.1.0-1&tid=100000&uid=user123&aid=wow%2Dext%2D1&res=1068x720&vp=420x360&cd=32"
     )
   end)
@@ -230,7 +254,7 @@ describe("tracker", function()
     local f2 = function()
       t:trackUnstructEvent("save-game", 23.0)
     end
-    assert.has_error(f2, "ue_px|ue_pr is required and must be a non-empty table, not [23]")
+    assert.has_error(f2, "ue_px|ue_pr is required and must be a non-empty table, not [23.0]")
   end)
 
   it("trackUnstructEvent() should error unless tstamp is a positive integer", function()
@@ -241,26 +265,40 @@ describe("tracker", function()
   end)
 
   it("trackUnstructEvent() should call httpGet() with the correct URL-encoded payload in the querystring", function()
+    stub(t, "_httpGet")
     t:encodeBase64(false)
+    t:setUserId("user123")
+    t:setAppId("wow-ext-1")
+    t:platform("tv")
+    t:setColorDepth(32)
+    t:setScreenResolution(1068, 720)
+    t:setViewport(420, 360)
     t:trackUnstructEvent(
       "save-game",
       { save_id = "4321", level_INT = 23, difficultyLevel = "HARD", dl_content = true },
       1369330929
     )
-    assert.spy(t._httpGet).was_called_with(
+    assert.stub(t._httpGet).was_called_with(
       "http://d3rkrsqld9gmqf.cloudfront.net/i?e=ue&ue_na=save%2Dgame&ue_pr=%7B%22difficultyLevel%22%3A%22HARD%22%2C%22dl%5Fcontent%22%3Atrue%2C%22level%24int%22%3A23%2C%22save%5Fid%22%3A%224321%22%7D&dtm=1369330929000&p=tv&tv=lua-0.1.0-1&tid=100000&uid=user123&aid=wow%2Dext%2D1&res=1068x720&vp=420x360&cd=32"
     )
   end)
 
   it("trackUnstructEvent() should call httpGet() with the correct Base64-encoded payload in the querystring", function()
+    stub(t, "_httpGet")
     t:encodeBase64(true)
+    t:setUserId("user123")
+    t:setAppId("wow-ext-1")
+    t:platform("tv")
+    t:setColorDepth(32)
+    t:setScreenResolution(1068, 720)
+    t:setViewport(420, 360)
     t:trackUnstructEvent(
       "load-game",
       { save_id = "4321", level_INT = 23, difficultyLevel = "HARD", dl_content = true },
       1369330929
     )
-    assert.spy(t._httpGet).was_called_with(
-      "http://d3rkrsqld9gmqf.cloudfront.net/i?e=ue&ue_na=load%2Dgame&ue_px=eyJkaWZmaWN1bHR5TGV2ZWwiOiJIQVJEIiwiZGxfY29udGVudCI6dHJ1ZSwibGV2ZWwkaW50IjoyMywic2F2ZV9pZCI6IjQzMjEifQ&dtm=1369330929000&p=tv&tv=lua-0.1.0-1&tid=100000&uid=user123&aid=wow%2Dext%2D1&res=1068x720&vp=420x360&cd=32"
+    assert.stub(t._httpGet).was_called_with(
+      "http://d3rkrsqld9gmqf.cloudfront.net/i?e=ue&ue_na=load%2Dgame&ue_px=eyJkaWZmaWN1bHR5TGV2ZWwiOiJIQVJEIiwiZGxfY29udGVudCI6dHJ1ZSwibGV2ZWwkaW50IjoyMywic2F2ZV9pZCI6IjQzMjEifQ==&dtm=1369330929000&p=tv&tv=lua-0.1.0-1&tid=100000&uid=user123&aid=wow%2Dext%2D1&res=1068x720&vp=420x360&cd=32"
     )
   end)
 end)

--- a/src/snowplow/tracker.lua
+++ b/src/snowplow/tracker.lua
@@ -32,11 +32,6 @@ local VERSION = "lua-0.1.0-1"
 local DEFAULT_ENCODE_BASE64 = true
 local DEFAULT_PLATFORM = "pc"
 local SUPPORTED_PLATFORMS = set.newSet({ "pc", "tv", "mob", "cnsl", "iot" })
-local HTTP_ERRORS = set.newSet({
-  "host not found",
-  "No address associated with name",
-  "No address associated with hostname",
-})
 
 -- --------------------------------------------------------------
 -- Factory to create a new Tracker
@@ -101,10 +96,13 @@ function httpGet(uri)
   local resp = {}
   local c = curl.easy({
     url = uri,
-  }):setopt_writefunction(table.insert, resp):perform()
+  }):setopt_writefunction(table.insert, resp)
+  local _, err = pcall(function()
+    c:perform()
+  end)
   local statusCode = c:getinfo(curl.INFO_RESPONSE_CODE)
 
-  if HTTP_ERRORS:contains(statusCode) then
+  if err ~= nil then
     return false, "Host [" .. uri .. "] not found (possible connectivity error)"
   else
     local code = tonumber(statusCode)
@@ -160,6 +158,7 @@ end
 -- Defaults to true.
 -- @param encode boolean: whether to base64-encode or not
 function Tracker:encodeBase64(encode)
+  validate.isBoolean("encode", encode)
   self.config.encodeBase64 = encode
 end
 


### PR DESCRIPTION
## bad1_spec.lua:
- add `local` to `status, err` to ensure proper variable scope
- remove hard-coded line number from error check
- make platform order alphabetical

## tracker_spec.lua:
- Fix state leak and update resulting failed tests
  - The tracker instance `t` was set at the beginning at the tests and used for every test. This means there was state leaking as config options were set, and subsequently tested for in other tests. `before_each` now creates a new tracker instance before each test

- set `_TEST` global
- set values tested in query string tests inside tests
- make platform order alphabetical
- remove non-local spy.on
- replace spy with stub, as we are only interested in the values being passed into `_httpGet`, not the effects of the function running
- 23 -> 23.0 in error message expected value

## tracker.lua:
- call c:perform() in `pcall` to capture error, rather than throwing, for checking to return the current error message
- the errors in HTTP_ERRORS are no longer needed, as they were relevant to luasocket (replaced with lua-curl)
- add boolean validation to Tracker:encodeBase64

## bad2_spec.lua:
- set _TEST global
- `require` 'snowplow' after global has been set