### PR TITLE
Implement Luacheck (close #25)

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,9 @@
+-- Ignore files copied from GitHub
+exclude_files = {
+    "src/snowplow/lib/json.lua",
+}
+
+-- Ignore the _TEST global
+read_globals = {
+    "_TEST",
+}

--- a/README.md
+++ b/README.md
@@ -60,6 +60,20 @@ Once installed, to run all tests:
 busted
 ```
 
+## Luacheck
+
+[Luacheck](https://github.com/lunarmodules/luacheck), a static analyser, is used with this project. To check all files, first install luacheck:
+
+```sh
+luarocks install luacheck
+```
+
+Then run:
+
+```sh
+luacheck .
+```
+
 ## Find out more
 
 | Technical Docs                  | Setup Guide               | Roadmap                 | Contributing                      |

--- a/spec/integration/bad2_spec.lua
+++ b/spec/integration/bad2_spec.lua
@@ -36,7 +36,8 @@ describe("Integration tests with HTTP/collector problems", function()
     assert.is_false(s)
     assert.are.equal(
       msg,
-      "Host [http://fake.cloudfront.net/i?e=se&se_ca=shop&se_ac=add%2Dto%2Dbasket&se_pr=units&se_va=2&dtm=1369330909000&p=cnsl&tv=lua-0.1.0-1&tid=100000] not found (possible connectivity error)"
+      "Host [http://fake.cloudfront.net/i?e=se&se_ca=shop&se_ac=add%2Dto%2Dbasket&se_pr=units&se_va=2&dtm=1369330909000"
+        .. "&p=cnsl&tv=lua-0.1.0-1&tid=100000] not found (possible connectivity error)"
     )
   end)
 
@@ -50,7 +51,8 @@ describe("Integration tests with HTTP/collector problems", function()
     assert.is_false(s)
     assert.are.equal(
       msg,
-      "Host [http://c.snplow.com/i?e=sv&sv_na=Game+HUD+2&dtm=1369330916000&p=tv&tv=lua-0.1.0-1&tid=100000&aid=wow%2Dext%2D1&res=1068x720] not found (possible connectivity error)"
+      "Host [http://c.snplow.com/i?e=sv&sv_na=Game+HUD+2&dtm=1369330916000&p=tv&tv=lua-0.1.0-1&tid=100000"
+        .. "&aid=wow%2Dext%2D1&res=1068x720] not found (possible connectivity error)"
     )
   end)
 end)

--- a/spec/unit/lib/base64_spec.lua
+++ b/spec/unit/lib/base64_spec.lua
@@ -28,11 +28,13 @@ describe("base64", function()
       { '{"myTemp":23.3,"myUnit":"celsius"}', "eyJteVRlbXAiOjIzLjMsIm15VW5pdCI6ImNlbHNpdXMifQ==" },
       {
         '{"event":"page_ping","mobile":true,"properties":{"max_x":960,"max_y":1080,"min_x":0,"min_y":-12}}',
-        "eyJldmVudCI6InBhZ2VfcGluZyIsIm1vYmlsZSI6dHJ1ZSwicHJvcGVydGllcyI6eyJtYXhfeCI6OTYwLCJtYXhfeSI6MTA4MCwibWluX3giOjAsIm1pbl95IjotMTJ9fQ==",
+        "eyJldmVudCI6InBhZ2VfcGluZyIsIm1vYmlsZSI6dHJ1ZSwicHJvcGVydGllcyI6eyJtYXhfeCI6OTYwLCJtYXhfeSI6MTA4MCwibWluX3giOj"
+          .. "AsIm1pbl95IjotMTJ9fQ==",
       },
       {
         '{"event":"basket_change","price":23.39,"product_id":"PBZ000345","quantity":-2,"tstamp":1678023000}',
-        "eyJldmVudCI6ImJhc2tldF9jaGFuZ2UiLCJwcmljZSI6MjMuMzksInByb2R1Y3RfaWQiOiJQQlowMDAzNDUiLCJxdWFudGl0eSI6LTIsInRzdGFtcCI6MTY3ODAyMzAwMH0=",
+        "eyJldmVudCI6ImJhc2tldF9jaGFuZ2UiLCJwcmljZSI6MjMuMzksInByb2R1Y3RfaWQiOiJQQlowMDAzNDUiLCJxdWFudGl0eSI6LTIsInRzdG"
+          .. "FtcCI6MTY3ODAyMzAwMH0=",
       },
     }
 
@@ -48,7 +50,7 @@ describe("base64", function()
   it("should error on nil and other datatypes", function()
     local bad_values = { nil, 1, true, false, 34.5 }
 
-    for i, v in pairs(bad_values) do
+    for _, v in pairs(bad_values) do
       assert.has_error(function()
         base64.encode(v)
       end)

--- a/spec/unit/lib/json_spec.lua
+++ b/spec/unit/lib/json_spec.lua
@@ -68,7 +68,7 @@ describe("json", function()
   it("should error on nil or other datatypes", function()
     local bad_values = { nil, "", 1, "temp => 23.C", true, false, 34.5 }
 
-    for i, v in ipairs(bad_values) do
+    for _, v in ipairs(bad_values) do
       assert.has_error(function()
         json:encode(v)
       end)

--- a/spec/unit/payload_spec.lua
+++ b/spec/unit/payload_spec.lua
@@ -54,7 +54,8 @@ describe("payload", function()
 
     assert.are.equal(
       pb.build(),
-      "?ue_pr=%7B%22max%5Fx%24flt%22%3A960%2C%22max%5Fy%24dt%22%3A1080%2C%22min%5Fx%24int%22%3A0%2C%22min%5Fy%24geo%22%3A%2D12%2C%22time%24tm%22%3A56565%2C%22time%24tms%22%3A56565%7D"
+      "?ue_pr=%7B%22max%5Fx%24flt%22%3A960%2C%22max%5Fy%24dt%22%3A1080%2C%22min%5Fx%24int%22%3A0%2C%22min%5Fy%24geo%22%"
+        .. "3A%2D12%2C%22time%24tm%22%3A56565%2C%22time%24tms%22%3A56565%7D"
     )
   end)
 

--- a/spec/unit/snowplow_spec.lua
+++ b/spec/unit/snowplow_spec.lua
@@ -16,7 +16,6 @@
 -- License:     Apache License Version 2.0
 
 local snowplow = require("snowplow")
-local validate = require("validate")
 local ss = require("lib.utils").safe_string -- Alias
 
 local function assert_tracker(tracker, collector_uri)

--- a/spec/unit/tracker_spec.lua
+++ b/spec/unit/tracker_spec.lua
@@ -176,9 +176,10 @@ describe("tracker", function()
     t:set_screen_resolution(1068, 720)
     t:set_viewport(420, 360)
 
-    local s, msg = t:track_screen_view("Game HUD 2", nil, 1369330916)
+    t:track_screen_view("Game HUD 2", nil, 1369330916)
     assert.stub(t._http_get).was_called_with(
-      "http://d3rkrsqld9gmqf.cloudfront.net/i?e=sv&sv_na=Game+HUD+2&dtm=1369330916000&p=tv&tv=lua-0.1.0-1&tid=100000&uid=user123&aid=wow%2Dext%2D1&res=1068x720&vp=420x360&cd=32"
+      "http://d3rkrsqld9gmqf.cloudfront.net/i?e=sv&sv_na=Game+HUD+2&dtm=1369330916000&p=tv&tv=lua-0.1.0-1&tid=100000"
+        .. "&uid=user123&aid=wow%2Dext%2D1&res=1068x720&vp=420x360&cd=32"
     )
   end)
 
@@ -234,7 +235,9 @@ describe("tracker", function()
     t:set_viewport(420, 360)
     t:track_struct_event("shop", "add-to-basket", nil, "units", 2, 1369330909)
     assert.stub(t._http_get).was_called_with(
-      "http://d3rkrsqld9gmqf.cloudfront.net/i?e=se&se_ca=shop&se_ac=add%2Dto%2Dbasket&se_pr=units&se_va=2&dtm=1369330909000&p=tv&tv=lua-0.1.0-1&tid=100000&uid=user123&aid=wow%2Dext%2D1&res=1068x720&vp=420x360&cd=32"
+      "http://d3rkrsqld9gmqf.cloudfront.net/i?e=se&se_ca=shop&se_ac=add%2Dto%2Dbasket&se_pr=units&se_va=2"
+        .. "&dtm=1369330909000&p=tv&tv=lua-0.1.0-1&tid=100000&uid=user123&aid=wow%2Dext%2D1&res=1068x720&vp=420x360"
+        .. "&cd=32"
     )
   end)
 
@@ -279,26 +282,33 @@ describe("tracker", function()
       1369330929
     )
     assert.stub(t._http_get).was_called_with(
-      "http://d3rkrsqld9gmqf.cloudfront.net/i?e=ue&ue_na=save%2Dgame&ue_pr=%7B%22difficultyLevel%22%3A%22HARD%22%2C%22dl%5Fcontent%22%3Atrue%2C%22level%24int%22%3A23%2C%22save%5Fid%22%3A%224321%22%7D&dtm=1369330929000&p=tv&tv=lua-0.1.0-1&tid=100000&uid=user123&aid=wow%2Dext%2D1&res=1068x720&vp=420x360&cd=32"
+      "http://d3rkrsqld9gmqf.cloudfront.net/i?e=ue&ue_na=save%2Dgame&ue_pr=%7B%22difficultyLevel%22%3A%22HARD%22%2C%22"
+        .. "dl%5Fcontent%22%3Atrue%2C%22level%24int%22%3A23%2C%22save%5Fid%22%3A%224321%22%7D&dtm=1369330929000&p=tv"
+        .. "&tv=lua-0.1.0-1&tid=100000&uid=user123&aid=wow%2Dext%2D1&res=1068x720&vp=420x360&cd=32"
     )
   end)
 
-  it("track_unstruct_event() should call http_get() with the correct Base64-encoded payload in the querystring", function()
-    stub(t, "_http_get")
-    t:encode_base64(true)
-    t:set_user_id("user123")
-    t:set_app_id("wow-ext-1")
-    t:platform("tv")
-    t:set_color_depth(32)
-    t:set_screen_resolution(1068, 720)
-    t:set_viewport(420, 360)
-    t:track_unstruct_event(
-      "load-game",
-      { save_id = "4321", level_INT = 23, difficultyLevel = "HARD", dl_content = true },
-      1369330929
-    )
-    assert.stub(t._http_get).was_called_with(
-      "http://d3rkrsqld9gmqf.cloudfront.net/i?e=ue&ue_na=load%2Dgame&ue_px=eyJkaWZmaWN1bHR5TGV2ZWwiOiJIQVJEIiwiZGxfY29udGVudCI6dHJ1ZSwibGV2ZWwkaW50IjoyMywic2F2ZV9pZCI6IjQzMjEifQ==&dtm=1369330929000&p=tv&tv=lua-0.1.0-1&tid=100000&uid=user123&aid=wow%2Dext%2D1&res=1068x720&vp=420x360&cd=32"
-    )
-  end)
+  it(
+    "track_unstruct_event() should call http_get() with the correct Base64-encoded payload in the querystring",
+    function()
+      stub(t, "_http_get")
+      t:encode_base64(true)
+      t:set_user_id("user123")
+      t:set_app_id("wow-ext-1")
+      t:platform("tv")
+      t:set_color_depth(32)
+      t:set_screen_resolution(1068, 720)
+      t:set_viewport(420, 360)
+      t:track_unstruct_event(
+        "load-game",
+        { save_id = "4321", level_INT = 23, difficultyLevel = "HARD", dl_content = true },
+        1369330929
+      )
+      assert.stub(t._http_get).was_called_with(
+        "http://d3rkrsqld9gmqf.cloudfront.net/i?e=ue&ue_na=load%2Dgame&ue_px=eyJkaWZmaWN1bHR5TGV2ZWwiOiJIQVJEIiwiZGxfY2"
+          .. "9udGVudCI6dHJ1ZSwibGV2ZWwkaW50IjoyMywic2F2ZV9pZCI6IjQzMjEifQ==&dtm=1369330929000&p=tv&tv=lua-0.1.0-1"
+          .. "&tid=100000&uid=user123&aid=wow%2Dext%2D1&res=1068x720&vp=420x360&cd=32"
+      )
+    end
+  )
 end)

--- a/spec/unit/validate_spec.lua
+++ b/spec/unit/validate_spec.lua
@@ -63,7 +63,7 @@ describe("validate", function()
       { "INPUT", "EXPECTED" },
       { { "hello" }, nil },
       { { 1, 2 }, nil },
-      { { a = 1, b = c }, nil },
+      { { a = 1, b = "c" }, nil },
       { { a = true, b = false }, nil },
       { nil, err("<nil>") },
       { {}, err("{}") },
@@ -106,7 +106,7 @@ describe("validate", function()
       { "", err("") },
       { nil, err("<nil>") },
       { {}, err("{}") },
-      { { a = 1, b = c }, err("<table>") },
+      { { a = 1, b = "c" }, err("<table>") },
       { 23.3, err(23.3) },
     }
 
@@ -125,7 +125,7 @@ describe("validate", function()
       { "", nil }, -- Difference from the above
       { nil, nil }, -- Difference from the above
       { {}, err("{}") },
-      { { a = 1, b = c }, err("<table>") },
+      { { a = 1, b = "c" }, err("<table>") },
       { 23.3, err(23.3) },
     }
 
@@ -152,7 +152,7 @@ describe("validate", function()
       { "", err("") },
       { nil, err("<nil>") },
       { {}, err("{}") },
-      { { a = 1, b = c }, err("<table>") },
+      { { a = 1, b = "c" }, err("<table>") },
       { 23.3, err(23.3) },
     }
 
@@ -172,7 +172,7 @@ describe("validate", function()
       { 4523000.29, nil },
       { nil, err("<nil>") },
       { "hello", err("hello") },
-      { { a = 1, b = c }, err("<table>") },
+      { { a = 1, b = "c" }, err("<table>") },
     }
 
     assert_data_table(data_table, validate.is_number)
@@ -191,7 +191,7 @@ describe("validate", function()
       { 4523000.29, nil },
       { nil, nil }, -- Only difference from the above
       { "hello", err("hello") },
-      { { a = 1, b = c }, err("<table>") },
+      { { a = 1, b = "c" }, err("<table>") },
     }
 
     assert_data_table(data_table, validate.is_number_or_nil)
@@ -211,7 +211,7 @@ describe("validate", function()
       { -10.586, err("-10.586") },
       { nil, err("<nil>") },
       { "hello", err("hello") },
-      { { a = 1, b = c }, err("<table>") },
+      { { a = 1, b = "c" }, err("<table>") },
     }
 
     assert_data_table(data_table, validate.is_positive_integer)

--- a/src/snowplow/payload.lua
+++ b/src/snowplow/payload.lua
@@ -29,7 +29,7 @@ payload.new_payload_builder = function(encode_base64)
   -- @param encode_base64 boolean: Whether properties and custom variables should be sent Base64 encoded or not
   -- @return table: The new payload
 
-  local payload = "?" -- What we're closing over
+  local new_payload = "?" -- What we're closing over
 
   -- Helper to add a &name=value pair to our payload aka querystring. Closes around payload
   -- @param key string: The name of the property
@@ -39,7 +39,7 @@ payload.new_payload_builder = function(encode_base64)
     local a, v
 
     if value ~= nil and value ~= "" then
-      if payload:len() > 1 then
+      if new_payload:len() > 1 then
         a = "&"
       else
         a = ""
@@ -49,7 +49,7 @@ payload.new_payload_builder = function(encode_base64)
       else
         v = value
       end
-      payload = payload .. a .. key .. "=" .. v
+      new_payload = new_payload .. a .. key .. "=" .. v
     end
   end
 
@@ -64,7 +64,7 @@ payload.new_payload_builder = function(encode_base64)
     -- the format expected by Snowplow
     local types = { "int", "flt", "geo", "dt", "tm", "tms" }
     for _, t in ipairs(types) do
-      suffix = '":' -- To lower risk of error
+      local suffix = '":' -- To lower risk of error
       local old = "_" .. t:upper() .. suffix
       local new = "$" .. t .. suffix
       props_json = props_json:gsub(old, new)
@@ -95,7 +95,8 @@ payload.new_payload_builder = function(encode_base64)
     add_nv_pair(key, value, false)
   end
 
-  -- Add a &name=value pair with the value base64 encoded, unless encode_base64 is set to false (in which case URI escape).
+  -- Add a &name=value pair with the value base64 encoded,
+  -- unless encode_base64 is set to false (in which case URI escape).
   -- @param key_if_enc string: The key name if the value is encoded - ue_pr: Unencoded, ue_px: Encoded
   -- @param key string: The name of the property
   -- @param value string: The value to add to the payload
@@ -104,7 +105,7 @@ payload.new_payload_builder = function(encode_base64)
     if type(validate) == "function" then
       validate((key_if_enc .. "|" .. key), value)
     end
-    props = to_properties_json(value)
+    local props = to_properties_json(value)
 
     if encode_base64 then
       if #props <= 0 then
@@ -119,7 +120,7 @@ payload.new_payload_builder = function(encode_base64)
   -- Our "builder" returns the payload string.
   -- @return string
   local build = function()
-    return payload
+    return new_payload
   end
 
   return {

--- a/src/snowplow/snowplow.lua
+++ b/src/snowplow/snowplow.lua
@@ -27,8 +27,7 @@ local snowplow = {}
 -- @param uri string: The full URI to the Snowplow collector
 -- @return tracker table: The new tracker
 local function init_tracker(uri)
-  local tracker = tracker.new_tracker(uri, config)
-  return tracker
+  return tracker.new_tracker(uri)
 end
 
 -- Helper to generate the collector url from a collector host name.

--- a/src/snowplow/tracker.lua
+++ b/src/snowplow/tracker.lua
@@ -55,9 +55,10 @@ end
 -- --------------------------------------------------------------
 -- Private static methods
 
--- Generates a moderately-unique six-digit transaction ID - essentially a nonce to make sure this event isn't recorded twice.
+-- Generates a moderately-unique six-digit transaction ID - essentially a nonce to make sure this event isn't
+-- recorded twice.
 -- @return string: The transaction ID
-function get_transaction_id()
+local function get_transaction_id()
   local tid
   math.randomseed(os.time())
   local rand = math.random(100000, 999999)
@@ -75,7 +76,7 @@ end
 -- Gets the current timestamp as total milliseconds since epoch.
 -- @param tstamp number: Optional time (in seconds since epoch) at which event occurred
 -- @return number: The timestamp
-function get_timestamp(tstamp)
+local function get_timestamp(tstamp)
   local timestamp
   if tstamp == nil then
     timestamp = os.time()
@@ -84,14 +85,13 @@ function get_timestamp(tstamp)
   else
     timestamp = tstamp -- Hope the calling code deals with the error
   end
-  local testVar
   return timestamp
 end
 
 -- GETs the given URI: this is how our event data is transmitted to the Snowplow collector.
 -- @param uri string: The URI (including querystring) to GET
 -- @return boolean, string: Whether event was successfully collected; and the reason for failure if not
-function http_get(uri)
+local function http_get(uri)
   -- `resp` is the table `:getinfo` reads from
   local resp = {}
   local c = curl.easy({
@@ -123,9 +123,10 @@ end
 
 -- Tracks any given SnowPlow event, by sending the specific event_pairs to the SnowPlow collector.
 -- @param: self table: The Tracker instance
--- @param pb table: A partially populated payload_builder closure. We will finish populating it in this method, then build() it
+-- @param pb table: A partially populated payload_builder closure. We will finish populating it in this method, then
+-- build() it
 -- @return boolean, string: Whether event was successfully collected; and the reason for failure if not
-function track(self, pb)
+local function track(self, pb)
   -- Add the standard name-value pairs
   pb.add("p", self.config.platform)
   pb.add_raw("tv", self.config.version)
@@ -235,7 +236,8 @@ end
 
 -- Sends a custom structured event to SnowPlow.
 -- @param category string: The name you supply for the group of objects you want to track
--- @param action string: A string that is uniquely paired with each category e.g. the type of user interaction for the object
+-- @param action string: A string that is uniquely paired with each category e.g. the type of user interaction for
+-- the object
 -- @param label string: An optional string to provide additional dimensions to the event data
 -- @param property string: An optional string describing the objector the action performed on it.
 -- @param value string: A value that you can use to provide numerical data about the user event
@@ -274,7 +276,7 @@ end
 
 if _TEST then
   -- A mock on the table to be checked by Busted. Does nothing - we will simply inspect the uri argument.
-  function Tracker._http_get(uri) end
+  function Tracker._http_get(uri) end -- luacheck: ignore
 end
 
 -- --------------------------------------------------------------


### PR DESCRIPTION
  - add section in README with instructions for Luacheck
  - add config file for Luacheck - `.luacheckrc`

  For Luacheck to pass, the following has been done:
  - remove unused variables
  - scope variables/functions correctly
  - split lines over 120 characters
  - rename/remove shadowing variables

[This line](https://github.com/snowplow/snowplow-lua-tracker/pull/26/commits/0e8ddb7b63f1372e395a5496f76fabbe99fd253b#diff-2e2b0c12c94a6121056f30b03d474718a5b41e671437ba55723ed30dc3484b2fR279) has been ignored, as it is currently only used in testing, and the `uri` parameter is intentionally un-used.