### PR TITLE
Replace transaction_id with event_id (close #27)

### DIFF
--- a/snowplowtracker-scm-1.rockspec
+++ b/snowplowtracker-scm-1.rockspec
@@ -17,7 +17,8 @@ description = {
 dependencies = {
   "lua >= 5.1",
   "lua-curl >= 0.3.13-1",
-  "base64 >= 1.5-2"
+  "base64 >= 1.5-2",
+  "lua_uuid >= 0.2.0-2"
 }
 build = {
   type = "builtin",

--- a/spec/integration/bad2_spec.lua
+++ b/spec/integration/bad2_spec.lua
@@ -20,6 +20,7 @@ local snowplow
 describe("Integration tests with HTTP/collector problems", function()
   setup(function()
     _G._TEST = true
+    package.loaded["lua_uuid"] = require("spec/mocks/mock_uuid")
     snowplow = require("snowplow")
   end)
 
@@ -39,7 +40,7 @@ describe("Integration tests with HTTP/collector problems", function()
       "Host [http://fake.cloudfront.net/i?e=se&se_ca=shop&se_ac=add%2Dto%2Dbasket&se_pr=units&se_va=2&dtm=1369330909000"
         .. "&p=cnsl&tv="
         .. t.config.version
-        .. "&tid=100000] not found (possible connectivity error)"
+        .. "&eid=00000000%2D0000%2D0000%2D0000%2D000000000000] not found (possible connectivity error)"
     )
   end)
 
@@ -55,7 +56,7 @@ describe("Integration tests with HTTP/collector problems", function()
       msg,
       "Host [http://c.snplow.com/i?e=sv&sv_na=Game+HUD+2&dtm=1369330916000&p=tv&tv="
         .. t.config.version
-        .. "&tid=100000"
+        .. "&eid=00000000%2D0000%2D0000%2D0000%2D000000000000"
         .. "&aid=wow%2Dext%2D1&res=1068x720] not found (possible connectivity error)"
     )
   end)

--- a/spec/mocks/mock_uuid.lua
+++ b/spec/mocks/mock_uuid.lua
@@ -1,0 +1,21 @@
+--- mock_uuid.lua
+--
+-- Copyright (c) 2022 Snowplow Analytics Ltd. All rights reserved.
+--
+-- This program is licensed to you under the Apache License Version 2.0,
+-- and you may not use this file except in compliance with the Apache License Version 2.0.
+-- You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the Apache License Version 2.0 is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+--
+-- Authors:     Greg Leonard
+-- Copyright:   Copyright (c) 2022 Snowplow Analytics Ltd
+-- License:     Apache License Version 2.0
+
+-- @return string: a known mock UUID for testing
+return function()
+  return "00000000-0000-0000-0000-000000000000"
+end

--- a/spec/unit/tracker_spec.lua
+++ b/spec/unit/tracker_spec.lua
@@ -15,7 +15,7 @@
 -- Copyright:   Copyright (c) 2013 Snowplow Analytics Ltd
 -- License:     Apache License Version 2.0
 
-local tracker = require("tracker")
+local tracker
 
 local collector_uri = "http://d3rkrsqld9gmqf.cloudfront.net/i"
 local TRACKER_VERSION = require("constants").TRACKER_VERSION
@@ -23,6 +23,8 @@ local TRACKER_VERSION = require("constants").TRACKER_VERSION
 describe("tracker", function()
   setup(function()
     _G._TEST = true
+    package.loaded["lua_uuid"] = require("spec/mocks/mock_uuid")
+    tracker = require("tracker")
   end)
 
   teardown(function()
@@ -181,7 +183,7 @@ describe("tracker", function()
     assert.stub(t._http_get).was_called_with(
       "http://d3rkrsqld9gmqf.cloudfront.net/i?e=sv&sv_na=Game+HUD+2&dtm=1369330916000&p=tv&tv="
         .. t.config.version
-        .. "&tid=100000"
+        .. "&eid=00000000%2D0000%2D0000%2D0000%2D000000000000"
         .. "&uid=user123&aid=wow%2Dext%2D1&res=1068x720&vp=420x360&cd=32"
     )
   end)
@@ -241,7 +243,7 @@ describe("tracker", function()
       "http://d3rkrsqld9gmqf.cloudfront.net/i?e=se&se_ca=shop&se_ac=add%2Dto%2Dbasket&se_pr=units&se_va=2"
         .. "&dtm=1369330909000&p=tv&tv="
         .. t.config.version
-        .. "&tid=100000&uid=user123&aid=wow%2Dext%2D1&res=1068x720&vp=420x360"
+        .. "&eid=00000000%2D0000%2D0000%2D0000%2D000000000000&uid=user123&aid=wow%2Dext%2D1&res=1068x720&vp=420x360"
         .. "&cd=32"
     )
   end)
@@ -292,7 +294,8 @@ describe("tracker", function()
         .. "dl%5Fcontent%22%3Atrue%2C%22level%24int%22%3A23%2C%22save%5Fid%22%3A%224321%22%7D&dtm=1369330929000&p=tv"
         .. "&tv="
         .. t.config.version
-        .. "&tid=100000&uid=user123&aid=wow%2Dext%2D1&res=1068x720&vp=420x360&cd=32"
+        .. "&eid=00000000%2D0000%2D0000%2D0000%2D000000000000&"
+        .. "uid=user123&aid=wow%2Dext%2D1&res=1068x720&vp=420x360&cd=32"
     )
   end)
 
@@ -316,8 +319,8 @@ describe("tracker", function()
         "http://d3rkrsqld9gmqf.cloudfront.net/i?e=ue&ue_na=load%2Dgame&ue_px=eyJkaWZmaWN1bHR5TGV2ZWwiOiJIQVJEIiwiZGxfY2"
           .. "9udGVudCI6dHJ1ZSwibGV2ZWwkaW50IjoyMywic2F2ZV9pZCI6IjQzMjEifQ==&dtm=1369330929000&p=tv&tv="
           .. t.config.version
-          .. ""
-          .. "&tid=100000&uid=user123&aid=wow%2Dext%2D1&res=1068x720&vp=420x360&cd=32"
+          .. "&eid=00000000%2D0000%2D0000%2D0000%2D000000000000"
+          .. "&uid=user123&aid=wow%2Dext%2D1&res=1068x720&vp=420x360&cd=32"
       )
     end
   )

--- a/src/snowplow/tracker.lua
+++ b/src/snowplow/tracker.lua
@@ -20,6 +20,7 @@ local validate = require("validate")
 local payload = require("payload")
 local set = require("lib.set")
 local ss = require("lib.utils").safe_string -- Alias
+local uuid = require("lua_uuid")
 local TRACKER_VERSION = require("constants").TRACKER_VERSION
 
 local tracker = {} -- The module
@@ -54,24 +55,6 @@ end
 
 -- --------------------------------------------------------------
 -- Private static methods
-
--- Generates a moderately-unique six-digit transaction ID - essentially a nonce to make sure this event isn't
--- recorded twice.
--- @return string: The transaction ID
-local function get_transaction_id()
-  local tid
-  math.randomseed(os.time())
-  local rand = math.random(100000, 999999)
-  tid = tostring(rand)
-
-  -- To handle testing
-  -- TODO: is there a cleaner way of doing this? DI or a mock or something?
-  if _TEST then
-    tid = "100000"
-  end
-
-  return tid
-end
 
 -- Gets the current timestamp as total milliseconds since epoch.
 -- @param tstamp number: Optional time (in seconds since epoch) at which event occurred
@@ -130,7 +113,7 @@ local function track(self, pb)
   -- Add the standard name-value pairs
   pb.add("p", self.config.platform)
   pb.add_raw("tv", self.config.version)
-  pb.add("tid", get_transaction_id())
+  pb.add("eid", uuid())
 
   -- Add the fields which may have been set
   pb.add("uid", self.user_id)


### PR DESCRIPTION
## replace tid with eid
tid (transaction id) is deprecated, and has been replaced with eid (event_id)

https://docs.snowplowanalytics.com/docs/collecting-data/collecting-from-own-applications/snowplow-tracker-protocol/#Event_transaction_parameters

## add `spec/mocks/mock_uuid.lua`

This allows us to use 
```lua
package.loaded["lua_uuid"] = require("spec/mocks/mock_uuid")
```
 to replace the entry in `package.loaded`, which Lua uses to control when and how modules are loaded, so when `require("lua_uuid")` is called in another file, it returns our `mock_uuid`.

The new package [lua_uuid](https://github.com/Kong/lua-uuid) simply returns a single function when `require`'d. By replacing this with our `mock_uuid` file, when `uuid()` is called in `tracker.lua` it runs the function in `mock_uuid`, which returns a known UUID.