### PR TITLE
Add support for dvce_sent_tstamp (close #14)

### DIFF
--- a/spec/integration/bad2_spec.lua
+++ b/spec/integration/bad2_spec.lua
@@ -35,17 +35,19 @@ describe("Integration tests with HTTP/collector problems", function()
     local _, msg = t:track_screen_view("Game HUD 2", nil)
 
     -- time returned by os.time when called in track_screen_view
-    local time = time_spy.returnvals[1].refs[1]
+    local dtm = time_spy.returnvals[1].refs[1]
+    local stm = time_spy.returnvals[2].refs[1]
 
     local expected = {
       "Host %[https://test%.invalid/i%?",
       "e=ue",
-      "dtm=" .. time,
+      "dtm=" .. dtm,
       "p=tv",
       "tv=" .. t.config.version:gsub("%.", "%%."):gsub("%-", "%%-"),
       "eid=%x%x%x%x%x%x%x%x%-%x%x%x%x%-%x%x%x%x%-%x%x%x%x%-%x%x%x%x%x%x%x%x%x%x%x%x", -- UUID pattern match
       "aid=wow%-ext%-1",
       "res=1068x720",
+      "stm=" .. stm,
       "] not found %(possible connectivity error%)",
     }
 

--- a/spec/integration/good1_spec.lua
+++ b/spec/integration/good1_spec.lua
@@ -19,12 +19,14 @@ local micro = require("spec.micro.micro")
 local snowplow = require("snowplow")
 
 describe("Integration tests with no issues", function()
+  local t
+
   before_each(function()
     micro.clear_cache()
+    t = snowplow.new_tracker(micro.get_url(), "GET")
   end)
 
   it("should return true for a valid collector", function()
-    local t = snowplow.new_tracker(micro.get_url(), "GET")
     t:encode_base64(false)
     t:set_screen_resolution(1068, 720)
     local s, msg = t:track_struct_event("name", "id")
@@ -34,7 +36,7 @@ describe("Integration tests with no issues", function()
   end)
 
   for _, request_type in ipairs({ "GET", "POST" }) do
-    local t = snowplow.new_tracker(micro.get_url(), request_type, true)
+    t = snowplow.new_tracker(micro.get_url(), request_type, true)
 
     it("can track a screen view using " .. request_type, function()
       local expected_id, expected_name = "test_id", "test_name"
@@ -90,4 +92,14 @@ describe("Integration tests with no issues", function()
       assert.are.equal(event.quantity, 1000)
     end)
   end
+
+  it("creates a dvce_sent_tstamp not less than dvce_created_tstamp", function()
+    local s, msg = t:track_struct_event("name", "id")
+    assert.is_true(s)
+    assert.is_nil(msg)
+
+    local micro_event = micro.get_good_events()
+    local event = micro_event[1].event
+    assert.is_true(event.dvce_created_tstamp <= event.dvce_sent_tstamp)
+  end)
 end)

--- a/src/snowplow/emitter.lua
+++ b/src/snowplow/emitter.lua
@@ -75,13 +75,17 @@ end
 
 --- Performs a GET request with a given payload to the collector.
 -- @tparam Emitter self The emitter
--- @tparam string payload The payload to send
+-- @tparam Payload payload The payload to send
 -- @treturn boolean Whether event was successfully collected
 -- @treturn ?string The reason for failure if not
 local function _get(self, payload)
-  local url = self.collector_url .. payload
   -- `resp` is the table `:getinfo` reads from
   local resp = {}
+
+  -- Add dvce_sent_tstamp
+  payload:add("stm", os.time())
+  local url = self.collector_url .. payload:build(self.request_method)
+
   local c = curl.easy({
     url = url,
   }):setopt_writefunction(table.insert, resp)
@@ -91,7 +95,7 @@ local function _get(self, payload)
   end)
 
   if err ~= nil then
-    return false, "Host [" .. self.collector_url .. payload .. "] not found (possible connectivity error)"
+    return false, "Host [" .. url .. "] not found (possible connectivity error)"
   end
 
   return handle_status_code(c:getinfo(curl.INFO_RESPONSE_CODE))
@@ -99,19 +103,23 @@ end
 
 --- Performs a POST request with a given payload to the collector.
 -- @tparam Emitter self The emitter
--- @tparam string payload The payload to send
+-- @tparam Payload payload The payload to send
 -- @treturn boolean Whether event was successfully collected
 -- @treturn ?string The reason for failure if not
 local function _post(self, payload)
   -- `resp` is the table `:getinfo` reads from
   local resp = {}
+
+  -- Add dvce_sent_tstamp
+  payload:add("stm", os.time())
+
   local c = curl.easy({
     url = self.collector_url,
     post = true,
     httpheader = {
       "Content-Type: application/json; charset=utf-8",
     },
-    postfields = payload,
+    postfields = payload:build(self.request_method),
   }):setopt_writefunction(table.insert, resp)
 
   local _, err = pcall(function()

--- a/src/snowplow/tracker.lua
+++ b/src/snowplow/tracker.lua
@@ -93,8 +93,7 @@ local function track(tracker_instance, pb)
     end
   end
 
-  local built_payload = pb:build(tracker_instance.emitter:get_request_method())
-  return tracker_instance.emitter:send(built_payload)
+  return tracker_instance.emitter:send(pb, tracker_instance)
 end
 
 -- --------------------------------------------------------------


### PR DESCRIPTION
This adds support for `dvce_sent_timestamp` which is standard across other trackers. Although Lua currently sends events synchronously, it is useful to have for the sake of consistency across trackers.