### PR TITLE
Fix API docs job (close #46)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Get LDoc and generate docs
         run: |
           wget https://github.com/lunarmodules/LDoc/archive/refs/tags/1.4.6.tar.gz &&
-          tar xf 1.4.6.tar.gz &&
+          tar xf 1.4.6.tar.gz --directory ./src/ &&
           cd ./src/
           lua ./LDoc-1.4.6/ldoc.lua .
 
@@ -65,7 +65,7 @@ jobs:
           publish_dir: ./src/doc/
 
   publish:
-    needs: "version_check"
+    needs: ["version_check", "docs"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
I must have dropped, rather than fixed up, the commit that set the output directory for tar, causing the job to fail as LDoc didn't exist in `src/`. The "docs" job has also been added to "needs" of the "publish" job, to avoid performing the release in the case of the docs job failing. 
