### PR TITLE
Simplify `track_unstruct_event` close (#48)

### DIFF
--- a/spec/integration/good1_spec.lua
+++ b/spec/integration/good1_spec.lua
@@ -73,10 +73,10 @@ describe("Integration tests with no issues", function()
     end)
 
     it("can track an unstruct event using " .. request_type, function()
-      local ok, err = t:track_unstruct_event({
-        schema = "iglu:com.snowplowanalytics.snowplow/add_to_cart/jsonschema/1-0-0",
-        data = { sku = "ASO01043", unitPrice = 49.95, quantity = 1000 },
-      })
+      local ok, err = t:track_self_describing_event(
+        "iglu:com.snowplowanalytics.snowplow/add_to_cart/jsonschema/1-0-0",
+        { sku = "ASO01043", unitPrice = 49.95, quantity = 1000 }
+      )
       assert.is_true(ok)
       assert.is_nil(err)
 

--- a/spec/unit/tracker_spec.lua
+++ b/spec/unit/tracker_spec.lua
@@ -16,6 +16,7 @@ local tracker
 local collector_url = "http://test.invalid/i"
 local TRACKER_VERSION = require("constants").TRACKER_VERSION
 local emitter = require("emitter")
+local ss = require("lib.utils").safe_string
 
 describe("tracker", function()
   local t
@@ -196,5 +197,42 @@ describe("tracker", function()
       t:track_struct_event("shop", "add-to-basket", nil, "units", "212")
     end
     assert.has_error(f, "value must be a number or nil, not [212]")
+  end)
+
+  it("track_self_describing_event() should error if schema is not a non-empty string", function()
+    local f = function(schema, data)
+      t:track_self_describing_event(schema, data)
+    end
+
+    local incorrect_schemas = {
+      { "", { key = "value" } },
+      { 1, { key = "value" } },
+      { true, { key = "value" } },
+      { {}, { key = "value" } },
+    }
+    for _, args in ipairs(incorrect_schemas) do
+      assert.has_error(function()
+        f(args[1], args[2])
+      end, "schema is required and must be a non-empty string, not [" .. ss(args[1]) .. "]")
+    end
+  end)
+
+  it("track_self_describing_event() should error if data is not a non-empty table", function()
+    local f = function(schema, data)
+      t:track_self_describing_event(schema, data)
+    end
+
+    local incorrect_data = {
+      { "iglu:example/schema", "" },
+      { "iglu:example/schema", 1 },
+      { "iglu:example/schema", true },
+      { "iglu:example/schema", {} },
+    }
+
+    for _, args in ipairs(incorrect_data) do
+      assert.has_error(function()
+        f(args[1], args[2])
+      end, "data is required and must be a non-empty table, not [" .. ss(args[2]) .. "]")
+    end
   end)
 end)

--- a/src/snowplow/tracker.lua
+++ b/src/snowplow/tracker.lua
@@ -33,7 +33,7 @@ local TRACKER_VERSION = require("constants").TRACKER_VERSION
 -- @func set_color_depth
 -- @func track_screen_view
 -- @func track_struct_event
--- @func track_unstruct_event
+-- @func track_self_describing_event
 -- @table Tracker
 
 local tracker = {} -- The module
@@ -173,15 +173,10 @@ function Tracker:track_screen_view(name, id)
   validate.is_non_empty_string("name", name)
   validate.is_non_empty_string_or_nil("id", id)
 
-  local screen_view = {
-    schema = "iglu:com.snowplowanalytics.snowplow/screen_view/jsonschema/1-0-0",
-    data = {
-      name = name,
-      id = id,
-    },
-  }
-
-  return self:track_unstruct_event(screen_view)
+  return self:track_self_describing_event("iglu:com.snowplowanalytics.snowplow/screen_view/jsonschema/1-0-0", {
+    name = name,
+    id = id,
+  })
 end
 
 --- Sends a custom structured event to Snowplow.
@@ -217,13 +212,20 @@ function Tracker:track_struct_event(category, action, label, property, value)
 end
 
 --- Sends a custom unstructured event to Snowplow.
--- @tab properties A key-value table of properties to send with the event
+-- @tab schema The schema for this event
+-- @tab data The key, value pairs to send with the event
 -- @treturn boolean Whether event was successfully collected
 -- @treturn ?string The reason for failure if not
-function Tracker:track_unstruct_event(properties)
+function Tracker:track_self_describing_event(schema, data)
+  validate.is_non_empty_string("schema", schema)
+  validate.is_non_empty_table("data", data)
+
   local wrapper = {
     schema = "iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0",
-    data = properties,
+    data = {
+      schema = schema,
+      data = data,
+    },
   }
   local pb = payload.new_payload_builder(self.config.encode_base64)
   pb:add("e", "ue")


### PR DESCRIPTION
This refactors `track_unstruct_event` to accept two arguments, `schema` and `data`, rather than a table with "schema" and "data" keys that must be constructed by the user, along with adding validation to the function.